### PR TITLE
Add content-length information and 'info' api mehtod

### DIFF
--- a/all-origins.js
+++ b/all-origins.js
@@ -14,17 +14,31 @@ function processRequest(req, res) {
   if (!isValidURL(params.url)) {
     return res.status(400).json({'error': 'invalid url'});
   }
-  getPageContent(params.url)
+  if (params.method === 'info') {
+    getPageData(params.url, true)
+    .then((response) => {
+      res.json({
+        'url': unescape(params.url),
+        'content_type': response.headers['content-type'],
+        'content_length': parseInt(response.headers['content-length']) || -1,
+        'http_code': response.statusCode
+      });
+    })
+    .catch((err) => res.status(400).json({'error': err}));
+    return;
+  }
+  getPageData(params.url, false)
   .then((page) => {
     let contentLength = Buffer.byteLength(page.content);
     res.set('Access-Control-Allow-Origin', '*');
     res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
 
-    if (params.method  && params.method === 'raw') {
+    if (params.method && params.method === 'raw') {
       res.set('Content-Length', contentLength);
       res.set('Content-Type', page.response.headers['content-type']);
       return res.send(page.content);
-    } else if (params.charset) {
+    }
+    if (params.charset) {
       res.set('Content-Type', `application/json; charset=${params.charset}`);
     } else {
       res.set('Content-Type', 'application/json');
@@ -45,11 +59,12 @@ function processRequest(req, res) {
   .catch((err) => res.status(400).json({'error': err}));
 }
 
-function getPageContent(url) {
+function getPageData(url, infoOnly) {
   return new Promise(resolver);
 
   function resolver(resolve, reject) {
     let requesOptions = {
+      'method': infoOnly ? 'HEAD' : 'GET',
       'url': url,
       'encoding': null,
       'headers': {
@@ -58,6 +73,7 @@ function getPageContent(url) {
     };
     request(requesOptions, function(error, response) {
       if (error) return reject(error);
+      if (infoOnly) return resolve(response);
       processContent(response)
       .then((res) => resolve(res))
       .catch((err) => reject(err));

--- a/all-origins.js
+++ b/all-origins.js
@@ -15,11 +15,13 @@ function processRequest(req, res) {
     return res.status(400).json({'error': 'invalid url'});
   }
   getPageContent(params.url)
-  .then(function (page) {
+  .then((page) => {
+    let contentLength = Buffer.byteLength(page.content);
     res.set('Access-Control-Allow-Origin', '*');
     res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
 
     if (params.method  && params.method === 'raw') {
+      res.set('Content-Length', contentLength);
       res.set('Content-Type', page.response.headers['content-type']);
       return res.send(page.content);
     } else if (params.charset) {
@@ -27,17 +29,17 @@ function processRequest(req, res) {
     } else {
       res.set('Content-Type', 'application/json');
     }
-
     let responseObj = {
       contents: page.content.toString(),
       status: {
         'url': unescape(params.url),
         'content_type': page.response.headers['content-type'],
+        'content_length': contentLength,
         'http_code': page.response.statusCode,
         'response_time': (new Date() - start)
       }
     };
-    if (params.callback) return res.jsonp(responseObj); 
+    if (params.callback) return res.jsonp(responseObj);
     return res.send(JSON.stringify(responseObj));
   })
   .catch((err) => res.status(400).json({'error': err}));


### PR DESCRIPTION
solve #8 
Now api response includes 'content_lenght' field on 'status' property or [`Content-Length`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length) header on `method=raw` requests. Content length information is given in `bytes`.

The API `mehtod=info` was also implemented. Info requests returns only information about the requested resource, but no content (only info provided by [`HEAD requests`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD)).