### PR TITLE
preflight support added

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,13 @@ start()
 function start () {
   const port = process.env.PORT || config.port
 
-  app.route('/get').get(allOrigins.processRequest)
+  app.route('/get')
+      .options(function processRequest (req, res) {
+          res.set('Access-Control-Allow-Origin', '*')
+          res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+          res.end()
+      })
+      .get(allOrigins.processRequest)
 
   app.listen(port)
   console.log('Listening on', port)


### PR DESCRIPTION
When I use this I got stuck with Chrome Pre-flight call which is doing a HTTP OPTIONS call to check whenever the endpoint has or not the Access-Control-Allow-Origin header.

You need to support also that method to make it work, otherwise we're still stuck with CORS issues.

`$.getJSON('https://allorigins.me/get?method=raw&url=https%3A%2F%2Fipapi.co%2Fjson')`

{readyState: 1, getResponseHeader: ƒ, getAllResponseHeaders: ƒ, setRequestHeader: ƒ, overrideMimeType: ƒ, …}

> Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost is therefore not allowed access.
