### PR TITLE
Make headers also work (Access-Control-Allow-Headers)

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ function enableCORS(req, res, next) {
   res.header('Access-Control-Allow-Credentials', true)
   res.header(
     'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Content-Encoding, Accept'
+    '*'
   )
   res.header(
     'Access-Control-Allow-Methods',


### PR DESCRIPTION
allOrigins is very useful and the only cors bypass that actually works (from the many I tried finding) but now it has a cors issue.
`Access-Control-Allow-Headers` isn't accepting any headers like `Upgrade-Insecure-Requests` which prevents some cases from being able to bypass cors.
So this PR will allow all headers