### PR TITLE
nodejs error for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-slim
+FROM node:16-slim
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY ./package.json /usr/src/app/


### PR DESCRIPTION
the current-slim errors out which is on node version 19.7.0

switch this to node:16-slim and it builds properly (used 16 based on travis)